### PR TITLE
Update creating-custom-class.md (fixes #40)

### DIFF
--- a/Documentation~/docs/4-fundamentals/creating-custom-class.md
+++ b/Documentation~/docs/4-fundamentals/creating-custom-class.md
@@ -16,6 +16,7 @@ namespace Custom.Variable
     {
     }
 
+    [Serializable]
     public struct Health
     {
         public float current;
@@ -26,3 +27,6 @@ namespace Custom.Variable
 
 Creating custom class is encouraged as you can setup the namespace in accordance to your projects.
 This is beneficial if you try to track references, so that you don't ended up in a general Kassets' namespace.
+
+**Serializable**
+It is important to note that your custom struct or class needs to have the Serializable attribute. Otherwise you will see null reference exceptions as the editor inspector cannot find the value of the class.


### PR DESCRIPTION
This PR addresses the issue:
NullReference exception when creating custom variable #40

By ensuring users of Kassets know that their custom variable classes or structs need to be serializable.

**Recommendation**
A recommended additional improvement is to add a null check to the inespctor GUI and issueing a more clear error message. Such that users are told their classes or structs need to have the serializable attribute.